### PR TITLE
Updated output for Smite and Rejuv Totem

### DIFF
--- a/docs/script/data.js
+++ b/docs/script/data.js
@@ -26,8 +26,12 @@ class Gem{
 			mod_text = mod_text.replace(/{.?}/g, '#');
 			mod_text = mod_text.replace(/You and nearby .llies .+? /g, '').trim();
 			mod_text = mod_text.replace(/.ura grants/g, '').trim();
-			if(mod_text.includes('per second'))
+			if(mod_text.includes('of Life per second'))
 				mod_text = 'Regenerate '+mod_text.replace('regenerated', '');
+			if(mod_text.includes('Mana per second'))
+				mod_text = 'Regenerate '+mod_text.replace('regenerated', '');
+			if(mod_text.includes('less Area Damage'))
+				mod_text = "";
 			if(!final_vals[mod_text])
 				final_vals[mod_text] = [];
 


### PR DESCRIPTION
Changed the mod text output to remove Smite's Less damage penalty and fix the "Regeneration Regeneration" on rejuvenation totem. The rest of the skills cannot be parsed by PoB at this time so for now this is the best we can achieve. Gotta wait for changes on their end for things like the Banners to parse.