### PR TITLE
Fixes For Excluding Royale Aura Versions and Non-"Per-Second" Stat Rounding

### DIFF
--- a/docs/script/data.js
+++ b/docs/script/data.js
@@ -83,11 +83,9 @@ class Gem {
 					continue;
 				}
 
-				if (val !== null && val !== undefined) {
-					if (mod.id.includes('per_minute')) val = val/60;
-					val = val * effect_increase * buff_eff;
-				}
-				val = Math.floor(val*100 || 0)/100;
+				val = val * effect_increase * buff_eff;
+				val = mod.id.includes('per_minute') ? Math.floor(val/60*100)/100 : Math.floor(val);
+				val = val || 0;
 				modText = modText.replace(/{[0-9]+}/, '#');
 				vals.push(val);
 			}

--- a/docs/script/data.js
+++ b/docs/script/data.js
@@ -139,10 +139,13 @@ class Data {
 				let base = this.data[key];
 				let ele = base['active_skill'];
 				if (!ele) return;
+				let baseItem = base['base_item'];
+				if (!baseItem) return;
 
 				const name = ele['display_name'];
 				if (!name
 					|| ignoredGems.includes(name)
+					|| baseItem['id'].includes('Royale')
 					|| !ele['types'].includes('aura')
 					|| ['totem', 'mine'].some(ig => ele['types'].includes(ig))
 					|| base.is_support

--- a/docs/script/data.js
+++ b/docs/script/data.js
@@ -137,17 +137,15 @@ class Data {
 				let base = this.data[key];
 				let ele = base['active_skill'];
 				if (!ele) return;
-				let baseItem = base['base_item'];
-				if (!baseItem) return;
 
 				const name = ele['display_name'];
 				if (!name
 					|| ignoredGems.includes(name)
-					|| baseItem['id'].includes('Royale')
 					|| !ele['types'].includes('aura')
 					|| ['totem', 'mine'].some(ig => ele['types'].includes(ig))
 					|| base.is_support
 					|| !base.base_item
+					|| base.base_item.id.includes('Royale')
 					|| !base.static.stats
 				) return;
 


### PR DESCRIPTION
Added fixes to prevent the duplicated PoE Royale versions of skills breaking the calculator, as well as the lack of rounding on stats that aren't calculated "per-second".

Fixes #9 
Fixes #10 