### PR TITLE
Cluster Jewel Notable Effect Updates & "Total % Increased Effect of Auras on You" Calculation Fix

### DIFF
--- a/docs/script/data.js
+++ b/docs/script/data.js
@@ -53,7 +53,7 @@ class Gem {
 	}
 
 	/** Returns an object, where each key is a generic stat line, and the value is the array of numbers to be inserted. */
-	levelStats(lvl, effect_increase, buff_eff){
+	levelStats(lvl, effect_increase){
 		console.log(this.name, 'level:', lvl)
 		if (!this.level_array[lvl]) {
 			lvl = Object.keys(this.level_array).reduce((acc, curr) => {
@@ -84,7 +84,7 @@ class Gem {
 					continue;
 				}
 
-				val = val * effect_increase * buff_eff;
+				val = val * effect_increase;
 				val = mod.id.includes('per_minute') ? Math.floor(val/60*100)/100 : Math.floor(val);
 				val = val || 0;
 				modText = modText.replace(/{[0-9]+}/, '#');
@@ -283,14 +283,17 @@ class Data {
 			
 			let percent_inc = parseInt($('#increase').val());
 			let buff_effect = parseInt($('#buffEffect').val());
-			
+
+			if (buff_effect>0)
+				percent_inc+= buff_effect;
+
 			if(this.gem_info[gem.name]['effect']>0)
 				percent_inc+= parseInt(this.gem_info[gem.name]['effect']);
 			
 			if(this.gem_info[gem.name]['generosity']>0)
 				percent_inc+= 19+parseInt(this.gem_info[gem.name]['generosity']);
 
-			let stats = gem.levelStats(this.gem_info[gem.name]['level'], 1 + (percent_inc/100), 1 + (buff_effect/100) );
+			let stats = gem.levelStats(this.gem_info[gem.name]['level'], 1 + (percent_inc/100));
 
 			if(Object.keys(stats).length>0){
 				let cont = $("<div>").addClass('stat_block');
@@ -397,8 +400,6 @@ class Data {
 		let asc_buffs = this.ascendancy;
 		Object.keys(asc_buffs).forEach((stat)=> {
 			let val = [Math.floor(asc_buffs[stat].total)];
-			if(asc_buffs[stat].scaling)
-				val = [Math.floor(asc_buffs[stat].total * 100 * (1+((parseInt($('#buffEffect').val()))/100))) / 100];
 			if(!asc_buffs[stat].total) return;
 			if(!grouped_stats[stat])
 				grouped_stats[stat] = val;

--- a/docs/script/data.js
+++ b/docs/script/data.js
@@ -237,15 +237,15 @@ class Data {
 		let sel = $('#preciseCommander').prop( "checked" );
 		if(sel)
 			return {
-				'#% increased Critical Strike Chance': {flat: 50},
-				'+#% to Global Critical Strike Multiplier': {flat: 15}
+				'#% increased Critical Strike Chance': {flat: 25},
+				'+#% to Global Critical Strike Multiplier': {flat: 10}
 			}
 	}
 	get_replenish(){
 		let sel = $('#replenishingPresence').prop( "checked" );
 		if (sel)
 			return {
-				'Regenerate #% of Life per second': {scaling: 0.2},
+				'Regenerate #% of Life per second': {flat: 1},
 			}
 	}
 
@@ -362,8 +362,7 @@ class Data {
 					if($('#replenishingPresence').prop( "checked" )){
 						Object.keys(this.replenish).forEach(name => {
 							let st = this.replenish[name];
-							st.total = st.total || 0;
-							st.total += (Math.floor(st.scaling * ( 1 + (percent_inc/100)) * 10) / 10);
+							st.total = st.flat
 						});
 					}
 
@@ -427,8 +426,6 @@ class Data {
 			let jewel_buffs = this.replenish;
 			Object.keys(jewel_buffs).forEach((stat)=> {
 				let val = [Math.floor(jewel_buffs[stat].total)];
-				if(jewel_buffs[stat].scaling)
-					val = [Math.floor(jewel_buffs[stat].total * 100 * (1+((parseInt($('#buffEffect').val()))/100))) / 100];
 				if(!jewel_buffs[stat].total) return;
 				if(!grouped_stats[stat])
 					grouped_stats[stat] = val;


### PR DESCRIPTION
The Precise Commander and Replenishing Presence cluster jewel notable effects weren't updated to the new values seen here:
[Precise Commander PoEDB](https://poedb.tw/us/Precise_Commander)
[Replenishing Presence PoEDB](https://poedb.tw/us/Replenishing_Presence)
Of note is Replenishing Presence, which changed from "Auras from your Skills grant" to "You and nearby Allies", so it's now a flat bonus instead of scaling with aura effect.

The calculation of "Total % Increased Effect of Auras on You" was incorrect as it was being multiplied with regular aura effect when it should've been added (tested both in-game and using Path of Building).