### PR TITLE
Gem JSON data filtering fix

### DIFF
--- a/docs/script/data.js
+++ b/docs/script/data.js
@@ -142,8 +142,8 @@ class Data {
 				const name = ele['display_name'];
 				if (!name
 					|| ignoredGems.includes(name)
-					|| !ele['types'].includes('aura')
-					|| ['totem', 'mine'].some(ig => ele['types'].includes(ig))
+					|| !ele['types'].includes('Aura')
+					|| ['SummonsTotem', 'RemoteMined'].some(ig => ele['types'].includes(ig))
 					|| base.is_support
 					|| !base.base_item
 					|| base.base_item.id.includes('Royale')


### PR DESCRIPTION
Updated JSON data change a few gem type names, breaking the filtering logic:
aura -> Aura
totem -> SummonsTotem
mine -> RemoteMined